### PR TITLE
Property fetcher aot2

### DIFF
--- a/test/OpenTelemetry.AotCompatibility.TestApp/OpenTelemetry.AotCompatibility.TestApp.csproj
+++ b/test/OpenTelemetry.AotCompatibility.TestApp/OpenTelemetry.AotCompatibility.TestApp.csproj
@@ -9,6 +9,10 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <Compile Include="$(RepoRoot)\src\Shared\DiagnosticSourceInstrumentation\PropertyFetcher.cs" Link="Includes\PropertyFetcher.cs" />
+  </ItemGroup>
+  
+  <ItemGroup>
     <TrimmerRootAssembly Include="OpenTelemetry.Api.ProviderBuilderExtensions" />
     <TrimmerRootAssembly Include="OpenTelemetry.Api" />
     <TrimmerRootAssembly Include="OpenTelemetry.Exporter.Console" />

--- a/test/OpenTelemetry.AotCompatibility.TestApp/Program.cs
+++ b/test/OpenTelemetry.AotCompatibility.TestApp/Program.cs
@@ -14,4 +14,17 @@
 // limitations under the License.
 // </copyright>
 
-Console.WriteLine("Hello, World!");
+using OpenTelemetry.AotCompatibility.TestApp;
+
+try
+{
+    PropertyFetcherAotTest.Test();
+}
+catch (Exception ex)
+{
+    Console.WriteLine(ex);
+    return -1;
+}
+
+Console.WriteLine("Passed.");
+return 0;

--- a/test/OpenTelemetry.AotCompatibility.TestApp/PropertyFetcherAotTest.cs
+++ b/test/OpenTelemetry.AotCompatibility.TestApp/PropertyFetcherAotTest.cs
@@ -1,0 +1,69 @@
+// <copyright file="PropertyFetcherAotTest.cs" company="OpenTelemetry Authors">
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// </copyright>
+
+using System.Diagnostics.CodeAnalysis;
+using OpenTelemetry.Instrumentation;
+
+namespace OpenTelemetry.AotCompatibility.TestApp;
+
+internal class PropertyFetcherAotTest
+{
+    [UnconditionalSuppressMessage("", "IL2026", Justification = "Property presence guaranteed by explicit hints")]
+    public static void Test()
+    {
+        var fetcher = new PropertyFetcher<BaseType>("Property");
+
+        GuaranteeProperties<PayloadTypeWithBaseType>();
+        var r = fetcher.TryFetch(new PayloadTypeWithBaseType(), out var value);
+        Assert(r, "TryFetch base did not return true");
+        Assert(value.GetType() == typeof(DerivedType), "TryFetch base value is not a derived type");
+
+        GuaranteeProperties<PayloadTypeWithDerivedType>();
+        r = fetcher.TryFetch(new PayloadTypeWithDerivedType(), out value);
+        Assert(r, "TryFetch derived did not return true");
+        Assert(value.GetType() == typeof(DerivedType), "TryFetch derived value is not a derived type");
+    }
+
+    private static void GuaranteeProperties<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicProperties)] T>()
+    {
+    }
+
+    private static void Assert(bool condition, string message)
+    {
+        if (!condition)
+        {
+            throw new InvalidOperationException(message);
+        }
+    }
+
+    private class BaseType
+    {
+    }
+
+    private class DerivedType : BaseType
+    {
+    }
+
+    private class PayloadTypeWithBaseType
+    {
+        public BaseType Property { get; set; } = new DerivedType();
+    }
+
+    private class PayloadTypeWithDerivedType
+    {
+        public DerivedType Property { get; set; } = new DerivedType();
+    }
+}

--- a/test/OpenTelemetry.Tests/Instrumentation/PropertyFetcherTest.cs
+++ b/test/OpenTelemetry.Tests/Instrumentation/PropertyFetcherTest.cs
@@ -78,6 +78,24 @@ public class PropertyFetcherTest
         Assert.Equal("A", propertyValue);
     }
 
+    [Fact]
+    public void FetchPropertyWithDerivedInstanceType()
+    {
+        var fetch = new PropertyFetcher<BaseType>("Property");
+
+        Assert.True(fetch.TryFetch(new PayloadTypeWithBaseType(), out BaseType value));
+        Assert.IsType<DerivedType>(value);
+    }
+
+    [Fact]
+    public void FetchPropertyWithDerivedDeclaredType()
+    {
+        var fetch = new PropertyFetcher<BaseType>("Property");
+
+        Assert.True(fetch.TryFetch(new PayloadTypeWithDerivedType(), out BaseType value));
+        Assert.IsType<DerivedType>(value);
+    }
+
     private class PayloadTypeA
     {
         public string Property { get; set; } = "A";
@@ -90,5 +108,23 @@ public class PropertyFetcherTest
 
     private class PayloadTypeC
     {
+    }
+
+    private class BaseType
+    {
+    }
+
+    private class DerivedType : BaseType
+    {
+    }
+
+    private class PayloadTypeWithBaseType
+    {
+        public BaseType Property { get; set; } = new DerivedType();
+    }
+
+    private class PayloadTypeWithDerivedType
+    {
+        public DerivedType Property { get; set; } = new DerivedType();
     }
 }


### PR DESCRIPTION
Reimplements the AOT parts of PropertyFetcher to always use CreateDelegate while being AOT compatible.
Simplifies the code by removing an entire class.

Also adds a test for different return types of properties.
Also adds an AOT test.
